### PR TITLE
One more bug

### DIFF
--- a/src/mumps_cmplx_p.f90
+++ b/src/mumps_cmplx_p.f90
@@ -225,6 +225,7 @@ logical,intent(in):: transpose  ! if .true. take the transpose
    ! The following is significant only on the host cpu.
    mumps_par%NRHS = nrhs  ! # of right-hand-sides
    mumps_par%LRHS = mumps_par%N  ! size of system
+   mumps_par%icntl(20) = 0 !Use dense rhs
 
    if (transpose) then
       mumps_par%icntl(9) = 0  ! for solving A'x = b

--- a/src/mumps_p.f90
+++ b/src/mumps_p.f90
@@ -197,6 +197,7 @@ logical,intent(in):: transpose  ! if .true. take the transpose
    ! The following is significant only on the host cpu.
    mumps_par%NRHS = nrhs  ! # of right-hand-sides
    mumps_par%LRHS = mumps_par%N  ! size of system
+   mumps_par%icntl(20) = 0  !Use dense rhs
 
    if (transpose) then
       mumps_par%icntl(9) = 0  ! for solving A'x = b


### PR DESCRIPTION
Hi Lars,
              Just after you merged the last pull request, a fellow student here at UBC found a bug. This pull request should fix it. The bug is as follows: If one creates a factorization with factorMUMPS, solves against a sparse rhs with applyMUMPS, then solves against a different dense rhs using the same factorization object, MUMPS will return the wrong solution. Code to reproduce the bug (Run from the MUMPS.jl/tests directory):
<pre> 
using MUMPS
include("getDivGrad.jl")
A = getDivGrad(32,32,16)
n = size(A,1)
rhs1 = sprand(n,1,0.05)
rhs2 = rand(n)
Ainv = factorMUMPS(A,1)
x1 = applyMUMPS(Ainv,rhs1)
x2 = applyMUMPSAinv,rhs2)
</pre>
After running this code you will find norm(x1-x2) is exactly zero, regardless of norm(rhs1-rhs2). This was a bug in our Fortran interface code. It was fixed by adding two lines of Fortran code. No julia code was changed.