### PR TITLE
Updated remotecall syntax for v0.5 and Compat and BaseTestNext

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.3
+Compat
+BaseTestNext

--- a/src/MUMPS.jl
+++ b/src/MUMPS.jl
@@ -1,5 +1,7 @@
 module MUMPS
 
+using Compat
+
 type MUMPSfactorization{T}
 	ptr::Int64     # pointer to factorization
 	worker::Int64  # id of worker that holds factorization

--- a/src/MUMPSfuncs.jl
+++ b/src/MUMPSfuncs.jl
@@ -75,7 +75,7 @@ function applyMUMPS{T1,T2,N}(factor::MUMPSfactorization{T1},rhs::AbstractArray{T
 	id1 = myid(); id2 = factor.worker
 	if id1 != id2
 		warn("Worker $id1 has no access to MUMPS factorization stored on $id2. Trying to remotecall!")
-		return remotecall_fetch(factor.worker,applyMUMPS,factor,rhs,x,tr)::Array{promote_type(T1,T2),N}
+		return remotecall_fetch(applyMUMPS,factor.worker,factor,rhs,x,tr)::Array{promote_type(T1,T2),N}
 	end
 	 
 	if size(rhs,1) != factor.n;  
@@ -146,7 +146,7 @@ function destroyMUMPS(factor::MUMPSfactorization{Float64})
 	 #  free memory
 	id1 = myid(); id2 = factor.worker;
 	if myid() != factor.worker
-		remotecall_fetch(id2,destroyMUMPS,factor)
+		remotecall_fetch(destroyMUMPS,id2,factor)
 		return
 	end
 	ccall( (:destroy_mumps_, MUMPSlibPath),
@@ -161,7 +161,7 @@ function destroyMUMPS(factor::MUMPSfactorization{Complex128})
 	 #  free memory
 	id1 = myid(); id2 = factor.worker;
 	if myid() != factor.worker
-		remotecall_fetch(id2,destroyMUMPS,factor)
+		remotecall_fetch(destroyMUMPS,id2,factor)
 		return
 	end
 	 ccall( (:destroy_mumps_cmplx_, MUMPSlibPath),

--- a/tests/benchmarkDivGrad.jl
+++ b/tests/benchmarkDivGrad.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 Ns = (8,16,24,32,48,64,72)
 MUMPStime=zeros(length(Ns))

--- a/tests/benchmarkDivGradComplex.jl
+++ b/tests/benchmarkDivGradComplex.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 Ns = (8,16,24,32,48,64)
 MUMPStime=zeros(length(Ns))

--- a/tests/benchmarkDivGradComplexSparseRHS.jl
+++ b/tests/benchmarkDivGradComplexSparseRHS.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 Ns   = (32,48,64)
 nrhs = (1,10,100,500)

--- a/tests/benchmarkDivGradOOC.jl
+++ b/tests/benchmarkDivGradOOC.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 Ns = (8,16,24,32,48,64)
 MUMPStime=zeros(length(Ns))

--- a/tests/benchmarkDivGradRealSparseRHS.jl
+++ b/tests/benchmarkDivGradRealSparseRHS.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 Ns   = (32,48,64)
 nrhs = (1,10,100,500)

--- a/tests/testDestroyMUMPS.jl
+++ b/tests/testDestroyMUMPS.jl
@@ -1,6 +1,12 @@
 # Factorize two different matrices (one real, one complex) and solve for multiple rhs and free memory
 @everywhere using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+using Compat
 include("getDivGrad.jl");
 
 Ar = getDivGrad(30,31,33);
@@ -25,8 +31,8 @@ println("Factorize real matrix on remote worker and destroy")
 tic();
 fact = 0;
 for i=1:100;
-	fact = remotecall_fetch( workers()[1] ,factorMUMPS, Ar,1)
-	remotecall_fetch(workers()[1],destroyMUMPS,fact)
+	fact = remotecall_fetch(factorMUMPS,workers()[1], Ar,1)
+	remotecall_fetch(destroyMUMPS,workers()[1],fact)
 end
 toc();
 

--- a/tests/testDivGrad.jl
+++ b/tests/testDivGrad.jl
@@ -1,6 +1,11 @@
 # Test for solving div-grad system both complex and real and single and multiple rhs
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 
 A = getDivGrad(32,32,16);

--- a/tests/testSparseRHS.jl
+++ b/tests/testSparseRHS.jl
@@ -1,5 +1,10 @@
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 
 A = getDivGrad(32,32,16);

--- a/tests/testTwoSystem.jl
+++ b/tests/testTwoSystem.jl
@@ -1,7 +1,12 @@
 # Factorize two different matrices (one real, one complex) and solve for multiple rhs and free memory
 
 using MUMPS
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 include("getDivGrad.jl");
 
 


### PR DESCRIPTION
Hi Lars,
             This PR updates MUMPS.jl for julia v0.5. It uses the Compat and BaseTestNext packages to maintain backward compatibility with v0.4. It's been tested on 0.4 and 0.5 but not on 0.3.

Patrick