### PR TITLE
Allow sparse rhs to be input as SparseVector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/metis-5.1.0/build
 src/metis-5.1.0/installed-libs
 src/MUMPS_5.0.1/examples
 *.cov
+*.mem

--- a/src/MUMPS.jl
+++ b/src/MUMPS.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module MUMPS
 
 using Compat
@@ -10,9 +12,9 @@ type MUMPSfactorization{T}
 	time::Float64  # factorization time
 end
 	const MUMPSlibPath  = abspath(joinpath(splitdir(Base.source_path())[1],"..","lib","MUMPS"))
-	
+
 	include("MUMPSfuncs.jl")
-	
+
 	export solveMUMPS,solveMUMPS!, factorMUMPS, applyMUMPS,applyMUMPS!,destroyMUMPS, MUMPSfactorization
-	
+
 end

--- a/src/MUMPSfuncs.jl
+++ b/src/MUMPSfuncs.jl
@@ -116,6 +116,19 @@ function applyMUMPS!(factor::MUMPSfactorization{Float64},rhs::SparseMatrixCSC{Fl
 	return x
 end
 
+function applyMUMPS!(factor::MUMPSfactorization{Float64},rhs::SparseVector{Float64}, x::Array{Float64,1},tr::Int=0)
+	nrhs = 1
+	nzrhs = nnz(rhs)
+	colptr = [1;3]
+	ptr = factor.ptr
+	ccall( (:solve_mumps_sparse_rhs_, MUMPSlibPath),
+              Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Float64}, Ptr{Int64}, Ptr{Int64},
+	      	  Ptr{Float64}, Ptr{Int64} ),
+		      &ptr, &nzrhs, &nrhs, rhs.nzval, rhs.nzind, colptr, x, &tr)
+
+	return x
+end
+
 function applyMUMPS!(factor::MUMPSfactorization{Complex128},rhs::Array{Complex128},
                       x::Array{Complex128},tr::Int=0)
 	n     = size(rhs,1)
@@ -140,7 +153,19 @@ ccall( (:solve_mumps_cmplx_sparse_rhs_, MUMPSlibPath),
 return x
 end
 
-	
+function applyMUMPS!(factor::MUMPSfactorization{Complex128},rhs::SparseVector{Complex128},
+                      x::Array{Complex128,1},tr::Int=0)
+nrhs = 1
+nzrhs = nnz(rhs)
+colptr = [1;3]
+ptr = factor.ptr
+ccall( (:solve_mumps_cmplx_sparse_rhs_, MUMPSlibPath),
+			Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Complex128}, Ptr{Int64}, 
+			Ptr{Int64}, Ptr{Complex64}, Ptr{Int64} ),
+			&ptr, &nzrhs,&nrhs, convert(Ptr{Complex128}, pointer(rhs.nzval)), rhs.nzind, 
+			colptr, convert(Ptr{Complex128}, pointer(x)), &tr)
+return x
+end	
 
 function destroyMUMPS(factor::MUMPSfactorization{Float64})
 	 #  free memory

--- a/src/MUMPSfuncs.jl
+++ b/src/MUMPSfuncs.jl
@@ -56,7 +56,7 @@ end
 
 function checkMUMPSerror(mumpsstat)
 	# check if MUMPS reported error
-	
+
 	if mumpsstat[1]==-10
 	     error("MUMPS: Numerically singular matrix.");
 	elseif mumpsstat[1]==-13
@@ -77,19 +77,19 @@ function applyMUMPS{T1,T2,N}(factor::MUMPSfactorization{T1},rhs::AbstractArray{T
 		warn("Worker $id1 has no access to MUMPS factorization stored on $id2. Trying to remotecall!")
 		return remotecall_fetch(applyMUMPS,factor.worker,factor,rhs,x,tr)::Array{promote_type(T1,T2),N}
 	end
-	 
-	if size(rhs,1) != factor.n;  
-		error("applyMUMPS: wrong size of rhs, size(A)=$(factor.n), size(rhs)=$(size(rhs,1)) x $(size(rhs,2))."); 
+
+	if size(rhs,1) != factor.n;
+		error("applyMUMPS: wrong size of rhs, size(A)=$(factor.n), size(rhs)=$(size(rhs,1)) x $(size(rhs,2)).");
 	end
-    
-	if size(x)!=size(rhs); 
+
+	if size(x)!=size(rhs);
 		if isempty(x)
 			x = zeros(promote_type(T1,T2),size(rhs))
 		else
-			error("applyMUMPS: wrong size of x, size(A)=$(factor.n), size(rhs)=$(size(rhs)), size(x)=$(size(x)) provided"); 
+			error("applyMUMPS: wrong size of x, size(A)=$(factor.n), size(rhs)=$(size(rhs)), size(x)=$(size(x)) provided");
 		end
 	end
-	
+
 	return applyMUMPS!(factor,rhs,x,tr)::Array{promote_type(T1,T2),N}
 end
 
@@ -119,7 +119,7 @@ end
 function applyMUMPS!(factor::MUMPSfactorization{Float64},rhs::SparseVector{Float64}, x::Array{Float64,1},tr::Int=0)
 	nrhs = 1
 	nzrhs = nnz(rhs)
-	colptr = [1;3]
+	colptr = [1; nzrhs+1]
 	ptr = factor.ptr
 	ccall( (:solve_mumps_sparse_rhs_, MUMPSlibPath),
               Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Float64}, Ptr{Int64}, Ptr{Int64},
@@ -146,9 +146,9 @@ nrhs = size(rhs,2)
 nzrhs = nnz(rhs)
 ptr = factor.ptr
 ccall( (:solve_mumps_cmplx_sparse_rhs_, MUMPSlibPath),
-			Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Complex128}, Ptr{Int64}, 
+			Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Complex128}, Ptr{Int64},
 			Ptr{Int64}, Ptr{Complex64}, Ptr{Int64} ),
-			&ptr, &nzrhs,&nrhs, convert(Ptr{Complex128}, pointer(rhs.nzval)), rhs.rowval, 
+			&ptr, &nzrhs,&nrhs, convert(Ptr{Complex128}, pointer(rhs.nzval)), rhs.rowval,
 			rhs.colptr, convert(Ptr{Complex128}, pointer(x)), &tr)
 return x
 end
@@ -157,15 +157,15 @@ function applyMUMPS!(factor::MUMPSfactorization{Complex128},rhs::SparseVector{Co
                       x::Array{Complex128,1},tr::Int=0)
 nrhs = 1
 nzrhs = nnz(rhs)
-colptr = [1;3]
+colptr = [1; nzrhs + 1]
 ptr = factor.ptr
 ccall( (:solve_mumps_cmplx_sparse_rhs_, MUMPSlibPath),
-			Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Complex128}, Ptr{Int64}, 
+			Void, (Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Complex128}, Ptr{Int64},
 			Ptr{Int64}, Ptr{Complex64}, Ptr{Int64} ),
-			&ptr, &nzrhs,&nrhs, convert(Ptr{Complex128}, pointer(rhs.nzval)), rhs.nzind, 
+			&ptr, &nzrhs,&nrhs, convert(Ptr{Complex128}, pointer(rhs.nzval)), rhs.nzind,
 			colptr, convert(Ptr{Complex128}, pointer(x)), &tr)
 return x
-end	
+end
 
 function destroyMUMPS(factor::MUMPSfactorization{Float64})
 	 #  free memory

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
+using Base.Test
+
 println("test MUMPS")
-include("testDivGrad.jl")
-include("testTwoSystem.jl")
-include("testTwoSystemParallel.jl")
-include("testSparseRHS.jl")
-println("Done!")
+@testset "MUMPS" begin
+    @testset "DivGrad" begin include("testDivGrad.jl") end
+    @testset "Two systems" begin include("testTwoSystem.jl") end
+    @testset "Two systems parallel" begin include("testTwoSystemParallel.jl") end
+    @testset "Sparse RHS" begin include("testSparseRHS.jl") end
+    println("Done!")
+end

--- a/test/testSparseRHS.jl
+++ b/test/testSparseRHS.jl
@@ -18,6 +18,13 @@ x = solveMUMPS(A,rhs,1);
 err  =  norm(A*x-full(rhs)) / norm(full(rhs));
 @test err < 1e-14
 
+# rhs as sparse vector instead of n X 1 sparse matrix
+rhs = vec(rhs)
+
+x = solveMUMPS(A,rhs,1);
+err  =  norm(A*x-full(rhs)) / norm(full(rhs));
+@test err < 1e-14
+
 # REAL: test for multiple rhs
 println("Test for real SPD matrix: multiple sparse random rhs");
 nrhs = 10;
@@ -50,7 +57,16 @@ println("Test for complex SPD matrix: one rhs");
 r = rand(n);
 A = A + im*spdiagm(r,0);
 
-rhs = sprandn(n,1,0.03) + im*sprandn(n,1,0.03);
+rhs = sprandn(n,1,0.03) + im*sprandn(n,1,0.03)
+
+x = solveMUMPS(A,rhs,2);
+
+err=  norm(A*x-full(rhs)) / norm(full(rhs))
+@test eltype(x) == Complex128
+@test err < 1e-14
+
+# sparse vector rhs
+rhs = vec(sprandn(n,1,0.03) + im*sprandn(n,1,0.03))
 
 x = solveMUMPS(A,rhs,2);
 


### PR DESCRIPTION
Currently need to input an n X 1 `SparseMatrixCSC` for single sparse rhs. Also added precompilation. 